### PR TITLE
fix: Renamed to TypedDomainNamespaceTest

### DIFF
--- a/XbrlDotNet.Tests/TypedDomainNamespaceTest.cs
+++ b/XbrlDotNet.Tests/TypedDomainNamespaceTest.cs
@@ -1,6 +1,6 @@
 namespace XbrlDotNet.Tests;
 
-public static class TypedOmainNamespaceTest
+public static class TypedDomainNamespaceTest
 {
     [XbrlTypedDomainNamespace("nl-cd", "http://www.nltaxonomie.nl/nt17/sbr/20220301/dictionary/nl-common-data")]
     private record TestContext([XbrlFact(Metric = "nl-cd")] string ChamberOfCommerceRegistrationNumber);


### PR DESCRIPTION
This pull request includes a small but important change to correct a typo in the class name of a test file. The change involves renaming the `TypedOmainNamespaceTest` class to `TypedDomainNamespaceTest`.

* [`XbrlDotNet.Tests/TypedDomainNamespaceTest.cs`](diffhunk://#diff-186c8343a71fca8d8a8561025333f9755838ed24d447f8e3a68de71bdfdb41a1L3-R3): Renamed the class from `TypedOmainNamespaceTest` to `TypedDomainNamespaceTest` to fix a typo.